### PR TITLE
fail build if migrations fail

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -14,5 +14,5 @@ echo "Pushing $GIT_REF to heroku app $HEROKU_APP..."
 set -e
 git push --force git@heroku.com:$HEROKU_APP.git $GIT_REF:master
 heroku config:set GIT_REF=`git rev-parse $GIT_REF` --app $HEROKU_APP
-heroku run rake db:migrate --app $HEROKU_APP
+heroku run --exit-code rake db:migrate --app $HEROKU_APP
 heroku restart --app $HEROKU_APP || heroku restart --app $HEROKU_APP || heroku restart --app $HEROKU_APP


### PR DESCRIPTION
This fixes a know heroku glitch in which they do not return the exit code of the command run... 
See also https://github.com/heroku/heroku/issues/186#issuecomment-98982942
